### PR TITLE
feat: Add toggle command for death message and improve grave item recovery

### DIFF
--- a/src/main/java/bzh/breizhhardware/cipautils/Main.java
+++ b/src/main/java/bzh/breizhhardware/cipautils/Main.java
@@ -1,6 +1,10 @@
 package bzh.breizhhardware.cipautils;
 
 import bzh.breizhhardware.cipautils.grave.GraveListener;
+import bzh.breizhhardware.cipautils.waystone.Waystone;
+import bzh.breizhhardware.cipautils.waystone.WaystoneListener;
+import bzh.breizhhardware.cipautils.waystone.WaystoneManager;
+import bzh.breizhhardware.cipautils.waystone.WaystoneRecipe;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -14,6 +18,7 @@ import java.util.List;
 public class Main extends JavaPlugin {
     private boolean spawnProtectionDisabled;
     private WaystoneManager waystoneManager;
+    private GraveListener graveListener;
 
     @Override
     public void onEnable() {
@@ -33,11 +38,13 @@ public class Main extends JavaPlugin {
         // Enregistrer les listeners
         getServer().getPluginManager().registerEvents(new WaystoneListener(this, waystoneManager), this);
         // Enregistrer le listener de tombe
-        getServer().getPluginManager().registerEvents(new GraveListener(this), this);
+        graveListener = new GraveListener(this);
+        getServer().getPluginManager().registerEvents(graveListener, this);
 
         // Enregistrer les commandes
         getCommand("nomorespawnprotect").setExecutor(this);
         getCommand("waystone").setExecutor(this);
+        getCommand("toggledeathmsg").setExecutor(graveListener.getToggleDeathMsgCommand());
 
         // Appliquer les paramètres
         if (spawnProtectionDisabled) {

--- a/src/main/java/bzh/breizhhardware/cipautils/grave/GraveListener.java
+++ b/src/main/java/bzh/breizhhardware/cipautils/grave/GraveListener.java
@@ -34,6 +34,8 @@ public class GraveListener implements Listener {
     private final Map<Location, UUID> graves = new HashMap<>();
     // Map pour stocker les inventaires custom des tombes
     private final Map<Location, Inventory> graveInventories = new HashMap<>();
+    // Set pour stocker les joueurs qui ont désactivé le message de mort
+    private final Set<UUID> deathMsgDisabled = new HashSet<>();
 
     public GraveListener(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -43,6 +45,12 @@ public class GraveListener implements Listener {
     public void onPlayerDeath(PlayerDeathEvent event) {
         Player player = event.getEntity();
         Location deathLoc = player.getLocation();
+
+        // Message d'information si activé
+        if (!deathMsgDisabled.contains(player.getUniqueId())) {
+            player.sendMessage("§eTip: Shift-right click your grave to automatically recover all your items!");
+            player.sendMessage("§7(Use /toggledeathmsg to disable this message)");
+        }
 
         Block barrelBlock = findBarrelLocation(deathLoc);
         if (barrelBlock == null) {
@@ -86,7 +94,40 @@ public class GraveListener implements Listener {
         Inventory graveInventory = graveInventories.get(loc);
         if (graveInventory == null) return;
         event.setCancelled(true);
-        event.getPlayer().openInventory(graveInventory);
+        Player player = event.getPlayer();
+        // Si le joueur fait un shift-clic droit
+        if (event.getAction() == org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK && player.isSneaking()) {
+            boolean allAdded = true;
+            ItemStack[] contents = graveInventory.getContents();
+            graveInventory.clear();
+            for (ItemStack item : contents) {
+                if (item != null) {
+                    HashMap<Integer, ItemStack> notAdded = player.getInventory().addItem(item);
+                    if (!notAdded.isEmpty()) {
+                        allAdded = false;
+                        // Remettre les items non ajoutés dans la tombe
+                        for (ItemStack left : notAdded.values()) {
+                            graveInventory.addItem(left);
+                        }
+                    }
+                }
+            }
+            if (graveInventory.isEmpty()) {
+                player.sendMessage("§aTous les items ont été transférés dans votre inventaire !");
+                block.setType(Material.AIR);
+                graveInventories.remove(loc);
+                UUID holoId = graves.get(loc);
+                graves.remove(loc);
+                if (holoId != null && Bukkit.getEntity(holoId) != null) {
+                    Bukkit.getEntity(holoId).remove();
+                }
+            } else {
+                player.sendMessage("§eVotre inventaire est plein, certains items sont restés dans la tombe !");
+            }
+        } else {
+            // Sinon, ouvrir l'inventaire normalement
+            player.openInventory(graveInventory);
+        }
     }
 
     @EventHandler
@@ -134,6 +175,18 @@ public class GraveListener implements Listener {
         // Si ce n'est pas une tombe, ne pas annuler les drops
     }
 
+    @EventHandler
+    public void onBlockExplode(org.bukkit.event.block.BlockExplodeEvent event) {
+        // Empêche la destruction des tombes (et pas tous les barrels) par explosion de bloc
+        event.blockList().removeIf(block -> graveInventories.containsKey(block.getLocation()));
+    }
+
+    @EventHandler
+    public void onEntityExplode(org.bukkit.event.entity.EntityExplodeEvent event) {
+        // Empêche la destruction des tombes (et pas tous les barrels) par explosion d'entité
+        event.blockList().removeIf(block -> graveInventories.containsKey(block.getLocation()));
+    }
+
     private Block findBarrelLocation(Location loc) {
         // Cherche un bloc d'air au-dessus d'un bloc solide dans les 3 blocs au-dessus
         for (int y = 0; y <= 3; y++) {
@@ -144,5 +197,21 @@ public class GraveListener implements Listener {
             }
         }
         return null;
+    }
+
+    public boolean isDeathMsgDisabled(UUID uuid) {
+        return deathMsgDisabled.contains(uuid);
+    }
+
+    public void setDeathMsgDisabled(UUID uuid, boolean disabled) {
+        if (disabled) {
+            deathMsgDisabled.add(uuid);
+        } else {
+            deathMsgDisabled.remove(uuid);
+        }
+    }
+
+    public ToggleDeathMsgCommand getToggleDeathMsgCommand() {
+        return new ToggleDeathMsgCommand(this);
     }
 }

--- a/src/main/java/bzh/breizhhardware/cipautils/grave/ToggleDeathMsgCommand.java
+++ b/src/main/java/bzh/breizhhardware/cipautils/grave/ToggleDeathMsgCommand.java
@@ -1,0 +1,32 @@
+package bzh.breizhhardware.cipautils.grave;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class ToggleDeathMsgCommand implements CommandExecutor {
+    private final GraveListener graveListener;
+
+    public ToggleDeathMsgCommand(GraveListener graveListener) {
+        this.graveListener = graveListener;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Commande réservée aux joueurs.");
+            return true;
+        }
+        Player player = (Player) sender;
+        boolean isDisabled = graveListener.isDeathMsgDisabled(player.getUniqueId());
+        if (isDisabled) {
+            graveListener.setDeathMsgDisabled(player.getUniqueId(), false);
+            player.sendMessage("§aLe message de mort est maintenant activé !");
+        } else {
+            graveListener.setDeathMsgDisabled(player.getUniqueId(), true);
+            player.sendMessage("§cLe message de mort est maintenant désactivé !");
+        }
+        return true;
+    }
+}

--- a/src/main/java/bzh/breizhhardware/cipautils/waystone/Waystone.java
+++ b/src/main/java/bzh/breizhhardware/cipautils/waystone/Waystone.java
@@ -1,4 +1,4 @@
-package bzh.breizhhardware.cipautils;
+package bzh.breizhhardware.cipautils.waystone;
 
 import org.bukkit.Location;
 

--- a/src/main/java/bzh/breizhhardware/cipautils/waystone/WaystoneGUI.java
+++ b/src/main/java/bzh/breizhhardware/cipautils/waystone/WaystoneGUI.java
@@ -1,5 +1,6 @@
-package bzh.breizhhardware.cipautils;
+package bzh.breizhhardware.cipautils.waystone;
 
+import bzh.breizhhardware.cipautils.Main;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;

--- a/src/main/java/bzh/breizhhardware/cipautils/waystone/WaystoneListener.java
+++ b/src/main/java/bzh/breizhhardware/cipautils/waystone/WaystoneListener.java
@@ -1,5 +1,6 @@
-package bzh.breizhhardware.cipautils;
+package bzh.breizhhardware.cipautils.waystone;
 
+import bzh.breizhhardware.cipautils.Main;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/java/bzh/breizhhardware/cipautils/waystone/WaystoneManager.java
+++ b/src/main/java/bzh/breizhhardware/cipautils/waystone/WaystoneManager.java
@@ -1,7 +1,7 @@
-package bzh.breizhhardware.cipautils;
+package bzh.breizhhardware.cipautils.waystone;
 
+import bzh.breizhhardware.cipautils.Main;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;

--- a/src/main/java/bzh/breizhhardware/cipautils/waystone/WaystoneRecipe.java
+++ b/src/main/java/bzh/breizhhardware/cipautils/waystone/WaystoneRecipe.java
@@ -1,5 +1,6 @@
-package bzh.breizhhardware.cipautils;
+package bzh.breizhhardware.cipautils.waystone;
 
+import bzh.breizhhardware.cipautils.Main;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,15 +5,14 @@ main: bzh.breizhhardware.cipautils.Main
 api-version: 1.21
 commands:
   nomorespawnprotect:
-    description: Contrôle la protection du spawn
-    usage: /nomorespawnprotect [toggle|status]
-    aliases: [nmsp]
-    permission: nomorespawnprotect.admin
+    description: Désactive la protection du spawn
+    usage: /nomorespawnprotect
   waystone:
-    description: Gestion des waystones
-    usage: /waystone [give|list|tp|info] [args...]
-    aliases: [ws]
-    permission: cipautils.waystone.use
+    description: Commandes pour les waystones
+    usage: /waystone
+  toggledeathmsg:
+    description: Active/désactive le message d'info sur la récupération automatique des tombes
+    usage: /toggledeathmsg
 permissions:
   nomorespawnprotect.admin:
     description: Permet de contrôler les paramètres du plugin


### PR DESCRIPTION
This pull request introduces several improvements and new features to the plugin, focusing on enhancing the grave system and refactoring the waystone code structure. The most significant changes include adding a toggleable tip message for grave recovery, enabling shift-right-click for automatic item retrieval from graves, protecting graves from explosions, and reorganizing waystone-related classes into a dedicated package.

**Grave system enhancements:**

* Added a toggleable tip message for players on death, informing them about shift-right-click grave recovery, with the option to disable the message via the new `/toggledeathmsg` command. [[1]](diffhunk://#diff-0e69ae8526f232b4aaa9f87477deefdecf885e614ecfa6e11cd2e308445e814eR37-R38) [[2]](diffhunk://#diff-0e69ae8526f232b4aaa9f87477deefdecf885e614ecfa6e11cd2e308445e814eR49-R54) [[3]](diffhunk://#diff-c206a568a659a2fe5018c5477ca1dec24030e6d00390c0435687b0de0055003cR1-R32) [[4]](diffhunk://#diff-4e857f730f7703b6b15173f5758c804b25afe947dca1ef3d9e0230b765e6f042L36-R47) [[5]](diffhunk://#diff-98201effe40eaf4a0e8826fadd6c5c9d5beaf9d737226b514f0853f44987a67fL8-R15)
* Implemented shift-right-click functionality on graves to automatically transfer all items to the player's inventory; items that don't fit remain in the grave, and the grave is removed if emptied.
* Added protection for graves against destruction by both block and entity explosions.

**Waystone codebase refactoring:**

* Moved all waystone-related classes (`Waystone`, `WaystoneListener`, `WaystoneManager`, `WaystoneGUI`, `WaystoneRecipe`) into the new `bzh.breizhhardware.cipautils.waystone` package for better organization and maintainability. [[1]](diffhunk://#diff-88aaf5360f3746af837341dd57379ebd0fefd6f66d899d7e4635dc571ec43888L1-R1) [[2]](diffhunk://#diff-87c20d6786f9ffab29278002958ff3f2fd572dcd0e739e1fd1777a0b46b1b896L1-R3) [[3]](diffhunk://#diff-2edc868f5a3d46b9095b334b450e6b74ed51bcac32528d5a012cea1a61724893L1-R3) [[4]](diffhunk://#diff-b561a47e2eb15bd01f57301da0deb4af23c9b4fbac9474dce27ca2d317f8e2b6L1-L4) [[5]](diffhunk://#diff-64befeed79a6a09233d8fb8065f97c0975d4ea218bb5ed4d8df4a2a1aa2e74d5L1-R3) [[6]](diffhunk://#diff-4e857f730f7703b6b15173f5758c804b25afe947dca1ef3d9e0230b765e6f042R4-R7)

**Plugin command configuration:**

* Updated `plugin.yml` to add the `/toggledeathmsg` command and simplified the descriptions/usages for existing commands.